### PR TITLE
feat: expand site translations

### DIFF
--- a/src/components/FeaturedServices.tsx
+++ b/src/components/FeaturedServices.tsx
@@ -3,32 +3,19 @@ import { Link } from 'react-router-dom';
 import signatureFacial from '@/assets/signature-facial.jpg';
 import bodyTreatment from '@/assets/body-treatment.jpg';
 import lashExtensions from '@/assets/lash-extensions.jpg';
+import { useTranslation } from 'react-i18next';
 const faceTreatmentImage = '/lovable-uploads/6240f13e-63be-4d28-ab8d-087c1f0a391c.png';
 
 const FeaturedServices = () => {
-  const services = [
-    {
-      title: 'AE Signature Facial',
-      description: 'Our signature facial uses high-frequency technology, exfoliation, and serums to restore your skin\'s natural balance.',
-      price: '$75',
-      duration: '60 mins',
-      image: faceTreatmentImage,
-    },
-    {
-      title: 'Full Body Treatment',
-      description: 'A complete skincare and relaxation session that includes cleansing, exfoliation, and nourishing treatments.',
-      price: '$130',
-      duration: '1h 30m',
-      image: bodyTreatment,
-    },
-    {
-      title: 'Lash Extensions',
-      description: 'Enhance your natural beauty with our professional lash extension services for a glamorous look.',
-      price: 'From $100',
-      duration: '3 hours',
-      image: lashExtensions,
-    },
-  ];
+  const { t } = useTranslation();
+  const services = t('featuredServices.items', {
+    returnObjects: true,
+  }) as Array<{ title: string; description: string; price: string; duration: string } & { image?: string }>;
+  // Attach images after translation
+  const servicesWithImages = services.map((service, index) => ({
+    ...service,
+    image: [faceTreatmentImage, bodyTreatment, lashExtensions][index],
+  }));
 
   return (
     <section className="section-light py-16 md:py-24">
@@ -36,20 +23,20 @@ const FeaturedServices = () => {
         {/* Section Header */}
         <div className="text-center mb-16">
           <h2 className="font-lavish text-4xl md:text-5xl text-foreground mb-4">
-            Signature <span className="text-primary">Services</span>
+            {t('featuredServices.title')} <span className="text-primary">{t('featuredServices.highlight')}</span>
           </h2>
           <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
-            Experience our most popular treatments designed to rejuvenate your skin and restore your inner glow.
+            {t('featuredServices.subtitle')}
           </p>
         </div>
 
         {/* Services Grid */}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-          {services.map((service, index) => (
+          {servicesWithImages.map((service, index) => (
             <div key={index} className="service-card">
               <div className="relative overflow-hidden">
-                <img 
-                  src={service.image} 
+                <img
+                  src={service.image}
                   alt={service.title}
                   className="w-full h-64 object-cover transition-transform duration-300 group-hover:scale-105"
                 />
@@ -69,7 +56,7 @@ const FeaturedServices = () => {
                 </p>
                 
                 <Button asChild className="btn-spa w-full">
-                  <Link to="/contact">Book Treatment</Link>
+                  <Link to="/contact">{t('featuredServices.book')}</Link>
                 </Button>
               </div>
             </div>
@@ -79,7 +66,7 @@ const FeaturedServices = () => {
         {/* View All Services CTA */}
         <div className="text-center mt-12">
           <Button asChild variant="outline" className="btn-outline-spa">
-            <Link to="/services">View All Services</Link>
+            <Link to="/services">{t('featuredServices.viewAll')}</Link>
           </Button>
         </div>
       </div>

--- a/src/components/Testimonials.tsx
+++ b/src/components/Testimonials.tsx
@@ -1,42 +1,15 @@
 import { useState, useEffect } from 'react';
 import { ChevronLeft, ChevronRight, Star } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { useTranslation } from 'react-i18next';
 
 const Testimonials = () => {
+  const { t } = useTranslation();
   const [currentIndex, setCurrentIndex] = useState(0);
 
-  const testimonials = [
-    {
-      name: "Sarah Johnson",
-      service: "AE Signature Facial",
-      rating: 5,
-      text: "Absolutely amazing experience! My skin has never looked better. The staff is so professional and the atmosphere is so relaxing. I can't wait to come back!",
-    },
-    {
-      name: "Maria Rodriguez",
-      service: "Full Body Treatment",
-      rating: 5,
-      text: "The full body treatment was pure luxury. I felt completely pampered and relaxed. The results were incredible - my skin feels so soft and renewed.",
-    },
-    {
-      name: "Emily Chen",
-      service: "Lash Extensions",
-      rating: 5,
-      text: "My lash extensions look absolutely perfect! The attention to detail is amazing. I receive compliments every day and feel so confident.",
-    },
-    {
-      name: "Jessica Williams",
-      service: "AE Luxe Facial",
-      rating: 5,
-      text: "The event-ready facial was exactly what I needed before my wedding. My skin was glowing and photos turned out amazing. Highly recommend!",
-    },
-    {
-      name: "Ashley Davis",
-      service: "Mommy & Me Package",
-      rating: 5,
-      text: "Such a wonderful bonding experience with my daughter. The staff made us both feel so special and comfortable. We're definitely coming back!",
-    },
-  ];
+  const testimonials = t('testimonials.list', {
+    returnObjects: true,
+  }) as Array<{ name: string; service: string; text: string; rating?: number }>;
 
   useEffect(() => {
     const timer = setInterval(() => {
@@ -62,10 +35,10 @@ const Testimonials = () => {
         {/* Section Header */}
         <div className="text-center mb-12">
           <h2 className="font-lavish text-4xl md:text-5xl text-foreground mb-4">
-            What Our Clients <span className="text-primary">Say</span>
+            {t('testimonials.title')} <span className="text-primary">{t('testimonials.highlight')}</span>
           </h2>
           <p className="text-lg text-muted-foreground">
-            Read about the transformative experiences of our valued clients
+            {t('testimonials.subtitle')}
           </p>
         </div>
 
@@ -74,7 +47,7 @@ const Testimonials = () => {
           <div className="card-spa text-center min-h-[300px] flex flex-col justify-center">
             <div className="mb-6">
               <div className="flex justify-center mb-4">
-                {[...Array(testimonials[currentIndex].rating)].map((_, i) => (
+                {[...Array(testimonials[currentIndex].rating || 5)].map((_, i) => (
                   <Star key={i} className="w-5 h-5 text-luxury-gold fill-current" />
                 ))}
               </div>

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -72,6 +72,244 @@ const resources = {
         wellness: "Wellness",
         glow: "Glow",
       },
+
+      // Featured Services
+      featuredServices: {
+        title: "Signature",
+        highlight: "Services",
+        subtitle:
+          "Experience our most popular treatments designed to rejuvenate your skin and restore your inner glow.",
+        items: [
+          {
+            title: "AE Signature Facial",
+            description:
+              "Our signature facial uses high-frequency technology, exfoliation, and serums to restore your skin's natural balance.",
+            price: "$75",
+            duration: "60 mins",
+          },
+          {
+            title: "Full Body Treatment",
+            description:
+              "A complete skincare and relaxation session that includes cleansing, exfoliation, and nourishing treatments.",
+            price: "$130",
+            duration: "1h 30m",
+          },
+          {
+            title: "Lash Extensions",
+            description:
+              "Enhance your natural beauty with our professional lash extension services for a glamorous look.",
+            price: "From $100",
+            duration: "3 hours",
+          },
+        ],
+        book: "Book Treatment",
+        viewAll: "View All Services",
+      },
+
+      // Testimonials
+      testimonials: {
+        title: "What Our Clients",
+        highlight: "Say",
+        subtitle:
+          "Read about the transformative experiences of our valued clients",
+        list: [
+          {
+            name: "Sarah Johnson",
+            service: "AE Signature Facial",
+            text:
+              "Absolutely amazing experience! My skin has never looked better. The staff is so professional and the atmosphere is so relaxing. I can't wait to come back!",
+          },
+          {
+            name: "Maria Rodriguez",
+            service: "Full Body Treatment",
+            text:
+              "The full body treatment was pure luxury. I felt completely pampered and relaxed. The results were incredible - my skin feels so soft and renewed.",
+          },
+          {
+            name: "Emily Chen",
+            service: "Lash Extensions",
+            text:
+              "My lash extensions look absolutely perfect! The attention to detail is amazing. I receive compliments every day and feel so confident.",
+          },
+          {
+            name: "Jessica Williams",
+            service: "AE Luxe Facial",
+            text:
+              "The event-ready facial was exactly what I needed before my wedding. My skin was glowing and photos turned out amazing. Highly recommend!",
+          },
+          {
+            name: "Ashley Davis",
+            service: "Mommy & Me Package",
+            text:
+              "Such a wonderful bonding experience with my daughter. The staff made us both feel so special and comfortable. We're definitely coming back!",
+          },
+        ],
+      },
+
+      // About Page
+      aboutPage: {
+        heroTitle: "About",
+        heroHighlight: "Aura Essence",
+        heroSubtitle:
+          "Where luxury meets wellness, and every treatment is designed to help you glow from within.",
+        ourStory: {
+          title: "Our Story",
+          paragraphs: [
+            "Founded with a passion for luxury wellness and skincare, Aura Essence LLC was born from the belief that everyone deserves to feel radiant, confident, and pampered. Our journey began with a simple vision: to create a sanctuary where advanced skincare meets personalized care.",
+            "Every treatment at Aura Essence is carefully curated to not just enhance your natural beauty, but to provide a transformative experience that rejuvenates both body and spirit. From our signature facials to our specialized body treatments, we combine cutting-edge techniques with premium products to deliver exceptional results.",
+            "Our commitment extends beyond skincare – we believe in empowering every client to embrace their unique beauty and feel confident in their own skin. This philosophy guides everything we do, from our personalized consultation process to our ongoing client relationships.",
+          ],
+        },
+        founder: {
+          title: "Our Founder",
+          paragraphs: [
+            "With over a decade of experience in luxury skincare and wellness, our founder brings expertise, passion, and an unwavering commitment to excellence to every aspect of Aura Essence.",
+            "Certified in advanced skincare techniques and dedicated to continuing education, our team ensures that every client receives the highest quality care and the most innovative treatments available.",
+          ],
+        },
+        difference: {
+          title: "What Makes Us",
+          highlight: "Different",
+          subtitle:
+            "Experience the Aura Essence difference through our unique approach to luxury wellness",
+          items: [
+            {
+              title: "Personalized Care",
+              description:
+                "Every treatment is customized to your unique skin type, concerns, and goals. We believe in individual attention and tailored experiences.",
+            },
+            {
+              title: "Premium Ingredients",
+              description:
+                "We use only the finest, clinically-proven ingredients and products from leading luxury skincare brands to ensure optimal results.",
+            },
+            {
+              title: "Relaxing Environment",
+              description:
+                "Our serene, luxurious space is designed to transport you from everyday stress to a peaceful sanctuary of wellness.",
+            },
+            {
+              title: "Advanced Techniques",
+              description:
+                "Our team stays current with the latest innovations in skincare technology and advanced treatment methodologies.",
+            },
+            {
+              title: "Holistic Approach",
+              description:
+                "We consider your overall wellness, combining skincare with relaxation techniques for comprehensive rejuvenation.",
+            },
+            {
+              title: "Ongoing Support",
+              description:
+                "Your skin journey doesn't end with your treatment. We provide guidance and support for your at-home skincare routine.",
+            },
+          ],
+        },
+        valuesSection: {
+          title: "Our",
+          highlight: "Values",
+          values: ["Luxury", "Comfort", "Confidence", "Wellness", "Glow"],
+          icons: ["✨", "🌿", "💫", "🧘‍♀️", "✨"],
+        },
+      },
+
+      // Contact Page
+      contactPage: {
+        heroTitle: "Book Your",
+        heroHighlight: "Treatment",
+        heroSubtitle:
+          "Let your glow journey begin. Contact us to schedule your personalized spa experience.",
+        formTitle: "Book Your Appointment",
+        labels: {
+          name: "Full Name *",
+          email: "Email *",
+          phone: "Phone Number",
+          service: "Preferred Service *",
+          preferredDate: "Preferred Date",
+          preferredTime: "Preferred Time",
+          message: "Additional Notes",
+        },
+        placeholders: {
+          service: "Select a service",
+          time: "Select time",
+          message: "Any specific requests, concerns, or questions...",
+        },
+        serviceOptions: [
+          "Mini Facial ($45)",
+          "AE Signature Facial ($75)",
+          "Lymphatic Drainage Facial ($90)",
+          "AE Luxe | Event Ready ($120)",
+          "Back Facial ($65)",
+          "Full Body Treatment ($130)",
+          "Classic Lash Set ($100)",
+          "Hybrid Lash Set ($120)",
+          "Volume Lash Set ($130)",
+          "Waxing Services",
+          "Custom Package",
+          "Consultation",
+        ],
+        timeOptions: [
+          "9:00 AM",
+          "10:00 AM",
+          "11:00 AM",
+          "12:00 PM",
+          "1:00 PM",
+          "2:00 PM",
+          "3:00 PM",
+          "4:00 PM",
+          "5:00 PM",
+        ],
+        submit: "Submit Booking Request",
+        contactWithin:
+          "We'll contact you within 24 hours to confirm your appointment.",
+        contactInfo: {
+          title: "Contact Information",
+          phoneNote: "Call or text for appointments",
+          emailNote: "Email for inquiries",
+          addressLine1: "123 Wellness Avenue",
+          addressLine2: "Luxury District, CT 06001",
+          addressNote: "Private parking available",
+        },
+        hours: {
+          title: "Business Hours",
+          monFri: "Monday - Friday",
+          saturday: "Saturday",
+          sunday: "Sunday",
+          note: "Extended hours available for special events and packages",
+        },
+        follow: {
+          title: "Follow Us",
+          instagram: "@auraessencellc",
+          facebook: "Aura Essence LLC",
+          note:
+            "Follow us for skincare tips, before & after photos, and special offers!",
+        },
+        policies: {
+          title: "Booking Policies",
+          items: [
+            {
+              title: "Cancellation Policy",
+              text:
+                "Please provide at least 24 hours notice for cancellations to avoid fees.",
+            },
+            {
+              title: "Late Arrival",
+              text:
+                "Late arrivals may result in shortened treatment time or rescheduling.",
+            },
+            {
+              title: "Health Conditions",
+              text:
+                "Please inform us of any allergies, medications, or skin conditions.",
+            },
+            {
+              title: "Age Requirements",
+              text:
+                "Children's services available for ages 10-14 with adult supervision.",
+            },
+          ],
+        },
+      },
     },
   },
   es: {
@@ -143,6 +381,245 @@ const resources = {
         confidence: "Confianza",
         wellness: "Bienestar",
         glow: "Brillo",
+      },
+
+      // Featured Services
+      featuredServices: {
+        title: "Servicios",
+        highlight: "Destacados",
+        subtitle:
+          "Experimenta nuestros tratamientos más populares diseñados para rejuvenecer tu piel y restaurar tu brillo interior.",
+        items: [
+          {
+            title: "Facial Característico AE",
+            description:
+              "Nuestro facial característico utiliza tecnología de alta frecuencia, exfoliación y sueros para restaurar el equilibrio natural de tu piel.",
+            price: "$75",
+            duration: "60 mins",
+          },
+          {
+            title: "Tratamiento Corporal Completo",
+            description:
+              "Una sesión completa de cuidado de la piel y relajación que incluye limpieza, exfoliación y tratamientos nutritivos.",
+            price: "$130",
+            duration: "1h 30m",
+          },
+          {
+            title: "Extensiones de Pestañas",
+            description:
+              "Realza tu belleza natural con nuestros servicios profesionales de extensión de pestañas para un look glamoroso.",
+            price: "Desde $100",
+            duration: "3 horas",
+          },
+        ],
+        book: "Reservar Tratamiento",
+        viewAll: "Ver Todos los Servicios",
+      },
+
+      // Testimonials
+      testimonials: {
+        title: "Lo que Nuestros Clientes",
+        highlight: "Dicen",
+        subtitle:
+          "Lee sobre las experiencias transformadoras de nuestros valiosos clientes",
+        list: [
+          {
+            name: "Sarah Johnson",
+            service: "Facial Característico AE",
+            text:
+              "¡Experiencia absolutamente increíble! Mi piel nunca ha lucido mejor. El personal es muy profesional y el ambiente muy relajante. ¡No puedo esperar para volver!",
+          },
+          {
+            name: "Maria Rodriguez",
+            service: "Tratamiento Corporal Completo",
+            text:
+              "El tratamiento corporal completo fue pura lujo. Me sentí completamente mimada y relajada. Los resultados fueron increíbles: mi piel se siente tan suave y renovada.",
+          },
+          {
+            name: "Emily Chen",
+            service: "Extensiones de Pestañas",
+            text:
+              "¡Mis extensiones de pestañas se ven absolutamente perfectas! La atención al detalle es increíble. Recibo cumplidos todos los días y me siento muy segura.",
+          },
+          {
+            name: "Jessica Williams",
+            service: "Facial AE Luxe",
+            text:
+              "El facial para eventos fue exactamente lo que necesitaba antes de mi boda. Mi piel estaba radiante y las fotos salieron increíbles. ¡Muy recomendado!",
+          },
+          {
+            name: "Ashley Davis",
+            service: "Paquete Mamá e Hija",
+            text:
+              "Una experiencia de unión maravillosa con mi hija. El personal nos hizo sentir tan especiales y cómodas. ¡Definitivamente volveremos!",
+          },
+        ],
+      },
+
+      // About Page
+      aboutPage: {
+        heroTitle: "Acerca de",
+        heroHighlight: "Aura Essence",
+        heroSubtitle:
+          "Donde el lujo se une al bienestar y cada tratamiento está diseñado para ayudarte a brillar desde adentro.",
+        ourStory: {
+          title: "Nuestra Historia",
+          paragraphs: [
+            "Fundada con una pasión por el bienestar y el cuidado de la piel de lujo, Aura Essence LLC nació de la creencia de que todos merecen sentirse radiantes, seguros y mimados. Nuestro viaje comenzó con una visión simple: crear un santuario donde el cuidado avanzado de la piel se encuentre con la atención personalizada.",
+            "Cada tratamiento en Aura Essence está cuidadosamente diseñado no solo para realzar tu belleza natural, sino para brindar una experiencia transformadora que rejuvenezca tanto el cuerpo como el espíritu. Desde nuestros faciales característicos hasta nuestros tratamientos corporales especializados, combinamos técnicas de vanguardia con productos premium para ofrecer resultados excepcionales.",
+            "Nuestro compromiso va más allá del cuidado de la piel: creemos en empoderar a cada cliente para que abrace su belleza única y se sienta seguro en su propia piel. Esta filosofía guía todo lo que hacemos, desde nuestro proceso de consulta personalizado hasta nuestras relaciones continuas con los clientes.",
+          ],
+        },
+        founder: {
+          title: "Nuestra Fundadora",
+          paragraphs: [
+            "Con más de una década de experiencia en cuidado de la piel y bienestar de lujo, nuestra fundadora aporta experiencia, pasión y un compromiso inquebrantable con la excelencia en cada aspecto de Aura Essence.",
+            "Certificado en técnicas avanzadas de cuidado de la piel y dedicado a la educación continua, nuestro equipo garantiza que cada cliente reciba la atención de la más alta calidad y los tratamientos más innovadores disponibles.",
+          ],
+        },
+        difference: {
+          title: "Qué Nos Hace",
+          highlight: "Diferentes",
+          subtitle:
+            "Experimenta la diferencia de Aura Essence a través de nuestro enfoque único del bienestar de lujo",
+          items: [
+            {
+              title: "Atención Personalizada",
+              description:
+                "Cada tratamiento se personaliza según tu tipo de piel, preocupaciones y objetivos. Creemos en la atención individual y experiencias a medida.",
+            },
+            {
+              title: "Ingredientes Premium",
+              description:
+                "Utilizamos solo los mejores ingredientes y productos clínicamente probados de las principales marcas de cuidado de la piel de lujo para garantizar resultados óptimos.",
+            },
+            {
+              title: "Ambiente Relajante",
+              description:
+                "Nuestro espacio sereno y lujoso está diseñado para transportarte del estrés cotidiano a un santuario pacífico de bienestar.",
+            },
+            {
+              title: "Técnicas Avanzadas",
+              description:
+                "Nuestro equipo se mantiene al día con las últimas innovaciones en tecnología de cuidado de la piel y metodologías de tratamiento avanzadas.",
+            },
+            {
+              title: "Enfoque Holístico",
+              description:
+                "Consideramos tu bienestar general, combinando el cuidado de la piel con técnicas de relajación para una rejuvenecimiento integral.",
+            },
+            {
+              title: "Apoyo Continuo",
+              description:
+                "Tu viaje de cuidado de la piel no termina con tu tratamiento. Brindamos orientación y apoyo para tu rutina de cuidado en casa.",
+            },
+          ],
+        },
+        valuesSection: {
+          title: "Nuestros",
+          highlight: "Valores",
+          values: ["Lujo", "Comodidad", "Confianza", "Bienestar", "Brillo"],
+          icons: ["✨", "🌿", "💫", "🧘‍♀️", "✨"],
+        },
+      },
+
+      // Contact Page
+      contactPage: {
+        heroTitle: "Reserva tu",
+        heroHighlight: "Tratamiento",
+        heroSubtitle:
+          "Que comience tu viaje de brillo. Contáctanos para programar tu experiencia de spa personalizada.",
+        formTitle: "Reserva tu Cita",
+        labels: {
+          name: "Nombre Completo *",
+          email: "Correo Electrónico *",
+          phone: "Número de Teléfono",
+          service: "Servicio Preferido *",
+          preferredDate: "Fecha Preferida",
+          preferredTime: "Hora Preferida",
+          message: "Notas Adicionales",
+        },
+        placeholders: {
+          service: "Selecciona un servicio",
+          time: "Selecciona una hora",
+          message: "Cualquier solicitud, preocupación o pregunta específica...",
+        },
+        serviceOptions: [
+          "Facial Mini ($45)",
+          "Facial Característico AE ($75)",
+          "Facial de Drenaje Linfático ($90)",
+          "AE Luxe | Listo para Evento ($120)",
+          "Facial de Espalda ($65)",
+          "Tratamiento Corporal Completo ($130)",
+          "Juego de Pestañas Clásicas ($100)",
+          "Juego de Pestañas Híbridas ($120)",
+          "Juego de Pestañas Volumen ($130)",
+          "Servicios de Depilación",
+          "Paquete Personalizado",
+          "Consulta",
+        ],
+        timeOptions: [
+          "9:00 AM",
+          "10:00 AM",
+          "11:00 AM",
+          "12:00 PM",
+          "1:00 PM",
+          "2:00 PM",
+          "3:00 PM",
+          "4:00 PM",
+          "5:00 PM",
+        ],
+        submit: "Enviar Solicitud de Reserva",
+        contactWithin:
+          "Nos pondremos en contacto contigo dentro de 24 horas para confirmar tu cita.",
+        contactInfo: {
+          title: "Información de Contacto",
+          phoneNote: "Llama o envía un texto para citas",
+          emailNote: "Correo para consultas",
+          addressLine1: "123 Avenida Wellness",
+          addressLine2: "Distrito de Lujo, CT 06001",
+          addressNote: "Estacionamiento privado disponible",
+        },
+        hours: {
+          title: "Horario de Atención",
+          monFri: "Lunes - Viernes",
+          saturday: "Sábado",
+          sunday: "Domingo",
+          note:
+            "Horarios extendidos disponibles para eventos especiales y paquetes",
+        },
+        follow: {
+          title: "Síguenos",
+          instagram: "@auraessencellc",
+          facebook: "Aura Essence LLC",
+          note:
+            "¡Síguenos para consejos de cuidado de la piel, fotos de antes y después, y ofertas especiales!",
+        },
+        policies: {
+          title: "Políticas de Reserva",
+          items: [
+            {
+              title: "Política de Cancelación",
+              text:
+                "Por favor proporciona al menos 24 horas de anticipación para cancelaciones y así evitar cargos.",
+            },
+            {
+              title: "Llegada Tarde",
+              text:
+                "Las llegadas tarde pueden resultar en una reducción del tiempo de tratamiento o reprogramación.",
+            },
+            {
+              title: "Condiciones de Salud",
+              text:
+                "Por favor infórmanos de cualquier alergia, medicamento o condición de la piel.",
+            },
+            {
+              title: "Requisitos de Edad",
+              text:
+                "Servicios para niños disponibles para edades de 10-14 con supervisión adulta.",
+            },
+          ],
+        },
       },
     },
   },

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,19 +1,27 @@
 import Navigation from '@/components/Navigation';
 import Footer from '@/components/Footer';
+import { useTranslation } from 'react-i18next';
 
 const About = () => {
+  const { t } = useTranslation();
+  const differenceItems = t('aboutPage.difference.items', {
+    returnObjects: true,
+  }) as Array<{ title: string; description: string }>;
+  const values = t('aboutPage.valuesSection.values', { returnObjects: true }) as string[];
+  const valueIcons = t('aboutPage.valuesSection.icons', { returnObjects: true }) as string[];
+
   return (
     <div className="min-h-screen">
       <Navigation />
-      
+
       {/* Hero Section */}
       <section className="section-gradient py-16 md:py-24">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <h1 className="font-lavish text-5xl md:text-6xl text-foreground mb-6">
-            About <span className="text-primary">Aura Essence</span>
+            {t('aboutPage.heroTitle')} <span className="text-primary">{t('aboutPage.heroHighlight')}</span>
           </h1>
           <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
-            Where luxury meets wellness, and every treatment is designed to help you glow from within.
+            {t('aboutPage.heroSubtitle')}
           </p>
         </div>
       </section>
@@ -23,40 +31,23 @@ const About = () => {
         <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
             <div>
-              <h2 className="heading-spa text-foreground mb-6">Our Story</h2>
+              <h2 className="heading-spa text-foreground mb-6">{t('aboutPage.ourStory.title')}</h2>
               <div className="space-y-4 text-muted-foreground leading-relaxed">
-                <p>
-                  Founded with a passion for luxury wellness and skincare, Aura Essence LLC was born from 
-                  the belief that everyone deserves to feel radiant, confident, and pampered. Our journey 
-                  began with a simple vision: to create a sanctuary where advanced skincare meets 
-                  personalized care.
-                </p>
-                <p>
-                  Every treatment at Aura Essence is carefully curated to not just enhance your natural beauty, 
-                  but to provide a transformative experience that rejuvenates both body and spirit. From our 
-                  signature facials to our specialized body treatments, we combine cutting-edge techniques 
-                  with premium products to deliver exceptional results.
-                </p>
-                <p>
-                  Our commitment extends beyond skincare – we believe in empowering every client to embrace 
-                  their unique beauty and feel confident in their own skin. This philosophy guides everything 
-                  we do, from our personalized consultation process to our ongoing client relationships.
-                </p>
+                {t('aboutPage.ourStory.paragraphs', { returnObjects: true })
+                  .map((p: string, idx: number) => (
+                    <p key={idx}>{p}</p>
+                  ))}
               </div>
             </div>
-            
+
             <div className="relative">
               <div className="bg-gradient-luxury rounded-2xl p-8 shadow-luxury">
-                <h3 className="text-2xl font-semibold text-luxury-gold-foreground mb-4">Our Founder</h3>
+                <h3 className="text-2xl font-semibold text-luxury-gold-foreground mb-4">{t('aboutPage.founder.title')}</h3>
                 <p className="text-luxury-gold-foreground/80 mb-4">
-                  With over a decade of experience in luxury skincare and wellness, our founder brings 
-                  expertise, passion, and an unwavering commitment to excellence to every aspect of 
-                  Aura Essence.
+                  {t('aboutPage.founder.paragraphs.0')}
                 </p>
                 <p className="text-luxury-gold-foreground/80">
-                  Certified in advanced skincare techniques and dedicated to continuing education, 
-                  our team ensures that every client receives the highest quality care and the most 
-                  innovative treatments available.
+                  {t('aboutPage.founder.paragraphs.1')}
                 </p>
               </div>
             </div>
@@ -69,40 +60,15 @@ const About = () => {
         <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-12">
             <h2 className="heading-spa text-spa-dark-foreground mb-4">
-              What Makes Us <span className="text-luxury-gold">Different</span>
+              {t('aboutPage.difference.title')} <span className="text-luxury-gold">{t('aboutPage.difference.highlight')}</span>
             </h2>
             <p className="text-lg text-spa-dark-foreground/80">
-              Experience the Aura Essence difference through our unique approach to luxury wellness
+              {t('aboutPage.difference.subtitle')}
             </p>
           </div>
 
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-            {[
-              {
-                title: "Personalized Care",
-                description: "Every treatment is customized to your unique skin type, concerns, and goals. We believe in individual attention and tailored experiences."
-              },
-              {
-                title: "Premium Ingredients",
-                description: "We use only the finest, clinically-proven ingredients and products from leading luxury skincare brands to ensure optimal results."
-              },
-              {
-                title: "Relaxing Environment",
-                description: "Our serene, luxurious space is designed to transport you from everyday stress to a peaceful sanctuary of wellness."
-              },
-              {
-                title: "Advanced Techniques",
-                description: "Our team stays current with the latest innovations in skincare technology and advanced treatment methodologies."
-              },
-              {
-                title: "Holistic Approach",
-                description: "We consider your overall wellness, combining skincare with relaxation techniques for comprehensive rejuvenation."
-              },
-              {
-                title: "Ongoing Support",
-                description: "Your skin journey doesn't end with your treatment. We provide guidance and support for your at-home skincare routine."
-              }
-            ].map((item, index) => (
+            {differenceItems.map((item, index) => (
               <div key={index} className="card-dark hover-scale">
                 <div className="w-12 h-12 bg-gradient-luxury rounded-full flex items-center justify-center mb-4 shadow-luxury">
                   <span className="text-luxury-gold-foreground font-bold text-lg">{index + 1}</span>
@@ -119,22 +85,16 @@ const About = () => {
       <section className="section-light py-16">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <h2 className="heading-spa text-foreground mb-12">
-            Our <span className="text-primary">Values</span>
+            {t('aboutPage.valuesSection.title')} <span className="text-primary">{t('aboutPage.valuesSection.highlight')}</span>
           </h2>
-          
+
           <div className="grid grid-cols-2 md:grid-cols-5 gap-8">
-            {[
-              { value: 'Luxury', icon: '✨' },
-              { value: 'Comfort', icon: '🌿' },
-              { value: 'Confidence', icon: '💫' },
-              { value: 'Wellness', icon: '🧘‍♀️' },
-              { value: 'Glow', icon: '✨' }
-            ].map((item, index) => (
+            {values.map((value, index) => (
               <div key={index} className="text-center hover-scale">
                 <div className="w-20 h-20 bg-gradient-primary rounded-full flex items-center justify-center mx-auto mb-4 text-2xl shadow-soft">
-                  {item.icon}
+                  {valueIcons[index]}
                 </div>
-                <h3 className="text-lg font-semibold text-foreground">{item.value}</h3>
+                <h3 className="text-lg font-semibold text-foreground">{value}</h3>
               </div>
             ))}
           </div>

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -7,8 +7,13 @@ import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useState } from 'react';
 import { Phone, Mail, MapPin, Clock, Instagram, Facebook } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 
 const Contact = () => {
+  const { t } = useTranslation();
+  const serviceOptions = t('contactPage.serviceOptions', { returnObjects: true }) as string[];
+  const timeOptions = t('contactPage.timeOptions', { returnObjects: true }) as string[];
+
   const [formData, setFormData] = useState({
     name: '',
     email: '',
@@ -41,10 +46,10 @@ const Contact = () => {
       <section className="section-gradient py-16 md:py-24">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <h1 className="heading-luxury text-foreground mb-6">
-            Book Your <span className="text-primary">Treatment</span>
+            {t('contactPage.heroTitle')} <span className="text-primary">{t('contactPage.heroHighlight')}</span>
           </h1>
           <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
-            Let your glow journey begin. Contact us to schedule your personalized spa experience.
+            {t('contactPage.heroSubtitle')}
           </p>
         </div>
       </section>
@@ -55,12 +60,12 @@ const Contact = () => {
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-12">
             {/* Contact Form */}
             <div className="card-spa">
-              <h2 className="text-2xl font-semibold text-foreground mb-6">Book Your Appointment</h2>
+              <h2 className="text-2xl font-semibold text-foreground mb-6">{t('contactPage.formTitle')}</h2>
               
               <form onSubmit={handleSubmit} className="space-y-6">
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   <div>
-                    <Label htmlFor="name">Full Name *</Label>
+                    <Label htmlFor="name">{t('contactPage.labels.name')}</Label>
                     <Input
                       id="name"
                       name="name"
@@ -72,7 +77,7 @@ const Contact = () => {
                     />
                   </div>
                   <div>
-                    <Label htmlFor="email">Email *</Label>
+                    <Label htmlFor="email">{t('contactPage.labels.email')}</Label>
                     <Input
                       id="email"
                       name="email"
@@ -86,7 +91,7 @@ const Contact = () => {
                 </div>
 
                 <div>
-                  <Label htmlFor="phone">Phone Number</Label>
+                  <Label htmlFor="phone">{t('contactPage.labels.phone')}</Label>
                   <Input
                     id="phone"
                     name="phone"
@@ -98,31 +103,22 @@ const Contact = () => {
                 </div>
 
                 <div>
-                  <Label htmlFor="service">Preferred Service *</Label>
+                  <Label htmlFor="service">{t('contactPage.labels.service')}</Label>
                   <Select required>
                     <SelectTrigger className="mt-1">
-                      <SelectValue placeholder="Select a service" />
+                      <SelectValue placeholder={t('contactPage.placeholders.service')} />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="mini-facial">Mini Facial ($45)</SelectItem>
-                      <SelectItem value="signature-facial">AE Signature Facial ($75)</SelectItem>
-                      <SelectItem value="lymphatic-facial">Lymphatic Drainage Facial ($90)</SelectItem>
-                      <SelectItem value="luxe-facial">AE Luxe | Event Ready ($120)</SelectItem>
-                      <SelectItem value="back-facial">Back Facial ($65)</SelectItem>
-                      <SelectItem value="full-body">Full Body Treatment ($130)</SelectItem>
-                      <SelectItem value="classic-lashes">Classic Lash Set ($100)</SelectItem>
-                      <SelectItem value="hybrid-lashes">Hybrid Lash Set ($120)</SelectItem>
-                      <SelectItem value="volume-lashes">Volume Lash Set ($130)</SelectItem>
-                      <SelectItem value="waxing">Waxing Services</SelectItem>
-                      <SelectItem value="custom-package">Custom Package</SelectItem>
-                      <SelectItem value="consultation">Consultation</SelectItem>
+                      {serviceOptions.map((option, index) => (
+                        <SelectItem key={index} value={String(index)}>{option}</SelectItem>
+                      ))}
                     </SelectContent>
                   </Select>
                 </div>
 
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   <div>
-                    <Label htmlFor="preferredDate">Preferred Date</Label>
+                    <Label htmlFor="preferredDate">{t('contactPage.labels.preferredDate')}</Label>
                     <Input
                       id="preferredDate"
                       name="preferredDate"
@@ -133,33 +129,27 @@ const Contact = () => {
                     />
                   </div>
                   <div>
-                    <Label htmlFor="preferredTime">Preferred Time</Label>
+                    <Label htmlFor="preferredTime">{t('contactPage.labels.preferredTime')}</Label>
                     <Select>
                       <SelectTrigger className="mt-1">
-                        <SelectValue placeholder="Select time" />
+                        <SelectValue placeholder={t('contactPage.placeholders.time')} />
                       </SelectTrigger>
                       <SelectContent>
-                        <SelectItem value="9:00">9:00 AM</SelectItem>
-                        <SelectItem value="10:00">10:00 AM</SelectItem>
-                        <SelectItem value="11:00">11:00 AM</SelectItem>
-                        <SelectItem value="12:00">12:00 PM</SelectItem>
-                        <SelectItem value="13:00">1:00 PM</SelectItem>
-                        <SelectItem value="14:00">2:00 PM</SelectItem>
-                        <SelectItem value="15:00">3:00 PM</SelectItem>
-                        <SelectItem value="16:00">4:00 PM</SelectItem>
-                        <SelectItem value="17:00">5:00 PM</SelectItem>
+                        {timeOptions.map((time, index) => (
+                          <SelectItem key={index} value={String(index)}>{time}</SelectItem>
+                        ))}
                       </SelectContent>
                     </Select>
                   </div>
                 </div>
 
                 <div>
-                  <Label htmlFor="message">Additional Notes</Label>
+                  <Label htmlFor="message">{t('contactPage.labels.message')}</Label>
                   <Textarea
                     id="message"
                     name="message"
                     rows={4}
-                    placeholder="Any specific requests, concerns, or questions..."
+                    placeholder={t('contactPage.placeholders.message')}
                     value={formData.message}
                     onChange={handleInputChange}
                     className="mt-1"
@@ -167,11 +157,11 @@ const Contact = () => {
                 </div>
 
                 <Button type="submit" className="btn-spa w-full text-lg py-3">
-                  Submit Booking Request
+                  {t('contactPage.submit')}
                 </Button>
 
                 <p className="text-sm text-muted-foreground text-center">
-                  We'll contact you within 24 hours to confirm your appointment.
+                  {t('contactPage.contactWithin')}
                 </p>
               </form>
             </div>
@@ -180,14 +170,14 @@ const Contact = () => {
             <div className="space-y-8">
               {/* Contact Details */}
               <div className="card-spa">
-                <h3 className="text-xl font-semibold text-foreground mb-6">Contact Information</h3>
+                <h3 className="text-xl font-semibold text-foreground mb-6">{t('contactPage.contactInfo.title')}</h3>
                 
                 <div className="space-y-4">
                   <div className="flex items-center space-x-3">
                     <Phone className="w-5 h-5 text-primary" />
                     <div>
                       <p className="font-medium text-foreground">(860) 849-8064</p>
-                      <p className="text-sm text-muted-foreground">Call or text for appointments</p>
+                      <p className="text-sm text-muted-foreground">{t('contactPage.contactInfo.phoneNote')}</p>
                     </div>
                   </div>
                   
@@ -195,16 +185,16 @@ const Contact = () => {
                     <Mail className="w-5 h-5 text-primary" />
                     <div>
                       <p className="font-medium text-foreground">hello@auraessence.com</p>
-                      <p className="text-sm text-muted-foreground">Email for inquiries</p>
+                      <p className="text-sm text-muted-foreground">{t('contactPage.contactInfo.emailNote')}</p>
                     </div>
                   </div>
                   
                   <div className="flex items-start space-x-3">
                     <MapPin className="w-5 h-5 text-primary mt-1" />
                     <div>
-                      <p className="font-medium text-foreground">123 Wellness Avenue</p>
-                      <p className="text-muted-foreground">Luxury District, CT 06001</p>
-                      <p className="text-sm text-muted-foreground">Private parking available</p>
+                      <p className="font-medium text-foreground">{t('contactPage.contactInfo.addressLine1')}</p>
+                      <p className="text-muted-foreground">{t('contactPage.contactInfo.addressLine2')}</p>
+                      <p className="text-sm text-muted-foreground">{t('contactPage.contactInfo.addressNote')}</p>
                     </div>
                   </div>
                 </div>
@@ -214,32 +204,32 @@ const Contact = () => {
               <div className="card-spa">
                 <h3 className="text-xl font-semibold text-foreground mb-6 flex items-center">
                   <Clock className="w-5 h-5 text-primary mr-2" />
-                  Business Hours
+                  {t('contactPage.hours.title')}
                 </h3>
                 
                 <div className="space-y-2">
                   <div className="flex justify-between">
-                    <span className="text-foreground">Monday - Friday</span>
+                    <span className="text-foreground">{t('contactPage.hours.monFri')}</span>
                     <span className="text-muted-foreground">9:00 AM - 7:00 PM</span>
                   </div>
                   <div className="flex justify-between">
-                    <span className="text-foreground">Saturday</span>
+                    <span className="text-foreground">{t('contactPage.hours.saturday')}</span>
                     <span className="text-muted-foreground">9:00 AM - 5:00 PM</span>
                   </div>
                   <div className="flex justify-between">
-                    <span className="text-foreground">Sunday</span>
+                    <span className="text-foreground">{t('contactPage.hours.sunday')}</span>
                     <span className="text-muted-foreground">By Appointment</span>
                   </div>
                 </div>
                 
                 <p className="text-sm text-primary mt-4 font-medium">
-                  Extended hours available for special events and packages
+                  {t('contactPage.hours.note')}
                 </p>
               </div>
 
               {/* Social Media */}
               <div className="card-spa">
-                <h3 className="text-xl font-semibold text-foreground mb-6">Follow Us</h3>
+                <h3 className="text-xl font-semibold text-foreground mb-6">{t('contactPage.follow.title')}</h3>
                 
                 <div className="flex space-x-4">
                   <a 
@@ -247,19 +237,19 @@ const Contact = () => {
                     className="flex items-center space-x-2 text-muted-foreground hover:text-primary transition-colors"
                   >
                     <Instagram className="w-5 h-5" />
-                    <span>@auraessencellc</span>
+                    <span>{t('contactPage.follow.instagram')}</span>
                   </a>
                   <a 
                     href="#" 
                     className="flex items-center space-x-2 text-muted-foreground hover:text-primary transition-colors"
                   >
                     <Facebook className="w-5 h-5" />
-                    <span>Aura Essence LLC</span>
+                    <span>{t('contactPage.follow.facebook')}</span>
                   </a>
                 </div>
                 
                 <p className="text-sm text-muted-foreground mt-4">
-                  Follow us for skincare tips, before & after photos, and special offers!
+                  {t('contactPage.follow.note')}
                 </p>
               </div>
             </div>
@@ -271,28 +261,17 @@ const Contact = () => {
       <section className="section-muted py-16">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="card-spa">
-            <h3 className="text-xl font-semibold text-foreground mb-6">Booking Policies</h3>
-            
+            <h3 className="text-xl font-semibold text-foreground mb-6">{t('contactPage.policies.title')}</h3>
+
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6 text-sm text-muted-foreground">
-              <div>
-                <h4 className="font-semibold text-foreground mb-2">Cancellation Policy</h4>
-                <p>Please provide at least 24 hours notice for cancellations to avoid fees.</p>
-              </div>
-              
-              <div>
-                <h4 className="font-semibold text-foreground mb-2">Late Arrival</h4>
-                <p>Late arrivals may result in shortened treatment time or rescheduling.</p>
-              </div>
-              
-              <div>
-                <h4 className="font-semibold text-foreground mb-2">Health Conditions</h4>
-                <p>Please inform us of any allergies, medications, or skin conditions.</p>
-              </div>
-              
-              <div>
-                <h4 className="font-semibold text-foreground mb-2">Age Requirements</h4>
-                <p>Children's services available for ages 10-14 with adult supervision.</p>
-              </div>
+              {t('contactPage.policies.items', { returnObjects: true }).map(
+                (item: { title: string; text: string }, index: number) => (
+                  <div key={index}>
+                    <h4 className="font-semibold text-foreground mb-2">{item.title}</h4>
+                    <p>{item.text}</p>
+                  </div>
+                )
+              )}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add translation resources for featured services, testimonials, about, and contact pages
- refactor related components and pages to use i18next keys

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype; Unexpected any; A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68962ef4305c832681ef1e04d9f0f29f