### PR TITLE
Remove hero phone number and unify contact email

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -54,13 +54,6 @@ const Hero = () => {
         </div>
       </div>
 
-      {/* Business Contact Info */}
-      <div className="absolute bottom-24 left-8 z-10 bg-white/10 backdrop-blur-sm rounded-lg p-4">
-        <div className="text-spa-dark-foreground/90 text-sm">
-          <p className="font-semibold">{t('phone')}</p>
-        </div>
-      </div>
-
       {/* Scroll indicator */}
       <div className="absolute bottom-8 left-1/2 transform -translate-x-1/2 z-10">
         <div className="w-6 h-10 border-2 border-spa-dark-foreground rounded-full flex justify-center">

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -184,7 +184,7 @@ const Contact = () => {
                   <div className="flex items-center space-x-3">
                     <Mail className="w-5 h-5 text-primary" />
                     <div>
-                      <p className="font-medium text-foreground">hello@auraessence.com</p>
+                      <p className="font-medium text-foreground">{t('email')}</p>
                       <p className="text-sm text-muted-foreground">{t('contactPage.contactInfo.emailNote')}</p>
                     </div>
                   </div>


### PR DESCRIPTION
## Summary
- remove phone number block from hero banner
- standardize contact email across site via i18n translation

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 3 errors in existing files)
- `npx eslint src/components/Hero.tsx src/pages/Contact.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689f5f5517bc8326a3380440f6f1f129