### PR TITLE
Send contact form to Formspree

### DIFF
--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -261,6 +261,8 @@ const resources = {
         submit: "Submit Booking Request",
         contactWithin:
           "We'll contact you within 24 hours to confirm your appointment.",
+        success: "Thank you for your message! We'll be in touch soon.",
+        error: "Oops! There was a problem submitting your form.",
         contactInfo: {
           title: "Contact Information",
           phoneNote: "Call or text for appointments",
@@ -926,6 +928,8 @@ const resources = {
         submit: "Enviar Solicitud de Reserva",
         contactWithin:
           "Nos pondremos en contacto contigo dentro de 24 horas para confirmar tu cita.",
+        success: "¡Gracias por tu mensaje! Nos pondremos en contacto pronto.",
+        error: "¡Ups! Hubo un problema al enviar tu formulario.",
         contactInfo: {
           title: "Información de Contacto",
           phoneNote: "Llama o envía un texto para citas",

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -24,12 +24,36 @@ const Contact = () => {
     preferredTime: '',
     message: ''
   });
+  const [status, setStatus] = useState<'success' | 'error' | null>(null);
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    // Handle form submission here
-    console.log('Form submitted:', formData);
-    // In a real app, you would send this data to your backend
+    try {
+      const response = await fetch('https://formspree.io/f/xyzdwkkv', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json'
+        },
+        body: JSON.stringify(formData)
+      });
+      if (response.ok) {
+        setStatus('success');
+        setFormData({
+          name: '',
+          email: '',
+          phone: '',
+          service: '',
+          preferredDate: '',
+          preferredTime: '',
+          message: ''
+        });
+      } else {
+        setStatus('error');
+      }
+    } catch {
+      setStatus('error');
+    }
   };
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
@@ -63,7 +87,12 @@ const Contact = () => {
             <div className="card-spa">
               <h2 className="text-2xl font-semibold text-foreground mb-6">{t('contactPage.formTitle')}</h2>
               
-              <form onSubmit={handleSubmit} className="space-y-6">
+              <form
+                onSubmit={handleSubmit}
+                action="https://formspree.io/f/xyzdwkkv"
+                method="POST"
+                className="space-y-6"
+              >
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   <div>
                     <Label htmlFor="name">{t('contactPage.labels.name')}</Label>
@@ -105,13 +134,21 @@ const Contact = () => {
 
                 <div>
                   <Label htmlFor="service">{t('contactPage.labels.service')}</Label>
-                  <Select required>
+                  <Select
+                    required
+                    value={formData.service}
+                    onValueChange={(value) =>
+                      setFormData({ ...formData, service: value })
+                    }
+                  >
                     <SelectTrigger className="mt-1">
                       <SelectValue placeholder={t('contactPage.placeholders.service')} />
                     </SelectTrigger>
                     <SelectContent>
                       {serviceOptions.map((option, index) => (
-                        <SelectItem key={index} value={String(index)}>{option}</SelectItem>
+                        <SelectItem key={index} value={option}>
+                          {option}
+                        </SelectItem>
                       ))}
                     </SelectContent>
                   </Select>
@@ -131,13 +168,20 @@ const Contact = () => {
                   </div>
                   <div>
                     <Label htmlFor="preferredTime">{t('contactPage.labels.preferredTime')}</Label>
-                    <Select>
+                    <Select
+                      value={formData.preferredTime}
+                      onValueChange={(value) =>
+                        setFormData({ ...formData, preferredTime: value })
+                      }
+                    >
                       <SelectTrigger className="mt-1">
                         <SelectValue placeholder={t('contactPage.placeholders.time')} />
                       </SelectTrigger>
                       <SelectContent>
                         {timeOptions.map((time, index) => (
-                          <SelectItem key={index} value={String(index)}>{time}</SelectItem>
+                          <SelectItem key={index} value={time}>
+                            {time}
+                          </SelectItem>
                         ))}
                       </SelectContent>
                     </Select>
@@ -164,6 +208,17 @@ const Contact = () => {
                 <p className="text-sm text-muted-foreground text-center">
                   {t('contactPage.contactWithin')}
                 </p>
+
+                {status === 'success' && (
+                  <p className="text-green-600 text-center">
+                    {t('contactPage.success')}
+                  </p>
+                )}
+                {status === 'error' && (
+                  <p className="text-red-600 text-center">
+                    {t('contactPage.error')}
+                  </p>
+                )}
               </form>
             </div>
 


### PR DESCRIPTION
## Summary
- Post contact form submissions to Formspree endpoint and show success or error status
- Capture selected service and appointment time values
- Add i18n strings for form submission success and error messages

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b3297966b8832697ab05afa193561d