### PR TITLE
feat: add dynamic gallery

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest",
+    "prebuild": "node scripts/build-gallery-manifest.mjs"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",

--- a/public/gallery/manifest.json
+++ b/public/gallery/manifest.json
@@ -1,0 +1,128 @@
+[
+  {
+    "id": "13",
+    "type": "video",
+    "src": "/gallery/AQOoN0ViRDBAM8t2JK9KdJtMEzgtuZe_31YvY4WSNVU6h3GU2XmfjOchGMUz057lEllkCKFQ90fpqgLZb0IgK68uMOek9WVQVCq9kpk.mp4",
+    "thumb": "/gallery/AQOoN0ViRDBAM8t2JK9KdJtMEzgtuZe_31YvY4WSNVU6h3GU2XmfjOchGMUz057lEllkCKFQ90fpqgLZb0IgK68uMOek9WVQVCq9kpk.mp4",
+    "folder": "/",
+    "filename": "AQOoN0ViRDBAM8t2JK9KdJtMEzgtuZe_31YvY4WSNVU6h3GU2XmfjOchGMUz057lEllkCKFQ90fpqgLZb0IgK68uMOek9WVQVCq9kpk.mp4",
+    "mtime": 1756588312250.6614
+  },
+  {
+    "id": "9",
+    "type": "image",
+    "src": "/gallery/3/534651726_17852187528521494_6617232410639955184_n.jpg",
+    "thumb": "/gallery/3/534651726_17852187528521494_6617232410639955184_n.jpg",
+    "folder": "3",
+    "filename": "534651726_17852187528521494_6617232410639955184_n.jpg",
+    "mtime": 1756588312246.6614
+  },
+  {
+    "id": "10",
+    "type": "image",
+    "src": "/gallery/536648945_17853078372521494_8340756371068533064_n.jpg",
+    "thumb": "/gallery/536648945_17853078372521494_8340756371068533064_n.jpg",
+    "folder": "/",
+    "filename": "536648945_17853078372521494_8340756371068533064_n.jpg",
+    "mtime": 1756588312246.6614
+  },
+  {
+    "id": "11",
+    "type": "image",
+    "src": "/gallery/538274409_17853078360521494_7912206241645111090_n.jpg",
+    "thumb": "/gallery/538274409_17853078360521494_7912206241645111090_n.jpg",
+    "folder": "/",
+    "filename": "538274409_17853078360521494_7912206241645111090_n.jpg",
+    "mtime": 1756588312246.6614
+  },
+  {
+    "id": "12",
+    "type": "video",
+    "src": "/gallery/AQOA_P2wiGNs0GH-0Ak4EeuAYmLb4vCqD2ABlUxLyHspP4DVCUQRAundUZGyuN0nrwkgU6aiVKhIg7rKuiYahpOzF3rp6__Ia4892w4.mp4",
+    "thumb": "/gallery/AQOA_P2wiGNs0GH-0Ak4EeuAYmLb4vCqD2ABlUxLyHspP4DVCUQRAundUZGyuN0nrwkgU6aiVKhIg7rKuiYahpOzF3rp6__Ia4892w4.mp4",
+    "folder": "/",
+    "filename": "AQOA_P2wiGNs0GH-0Ak4EeuAYmLb4vCqD2ABlUxLyHspP4DVCUQRAundUZGyuN0nrwkgU6aiVKhIg7rKuiYahpOzF3rp6__Ia4892w4.mp4",
+    "mtime": 1756588312246.6614
+  },
+  {
+    "id": "5",
+    "type": "image",
+    "src": "/gallery/2/535057488_17852155545521494_2421545910964367241_n.jpg",
+    "thumb": "/gallery/2/535057488_17852155545521494_2421545910964367241_n.jpg",
+    "folder": "2",
+    "filename": "535057488_17852155545521494_2421545910964367241_n.jpg",
+    "mtime": 1756588312242.6614
+  },
+  {
+    "id": "6",
+    "type": "image",
+    "src": "/gallery/3/534206898_17852187501521494_2901543617898039731_n.jpg",
+    "thumb": "/gallery/3/534206898_17852187501521494_2901543617898039731_n.jpg",
+    "folder": "3",
+    "filename": "534206898_17852187501521494_2901543617898039731_n.jpg",
+    "mtime": 1756588312242.6614
+  },
+  {
+    "id": "7",
+    "type": "image",
+    "src": "/gallery/3/534543348_17852187519521494_6102916905713103838_n.jpg",
+    "thumb": "/gallery/3/534543348_17852187519521494_6102916905713103838_n.jpg",
+    "folder": "3",
+    "filename": "534543348_17852187519521494_6102916905713103838_n.jpg",
+    "mtime": 1756588312242.6614
+  },
+  {
+    "id": "8",
+    "type": "image",
+    "src": "/gallery/3/534569883_17852187510521494_2988987948909929770_n.jpg",
+    "thumb": "/gallery/3/534569883_17852187510521494_2988987948909929770_n.jpg",
+    "folder": "3",
+    "filename": "534569883_17852187510521494_2988987948909929770_n.jpg",
+    "mtime": 1756588312242.6614
+  },
+  {
+    "id": "3",
+    "type": "image",
+    "src": "/gallery/1/532017232_17851502520521494_2246823012332408389_n.jpg",
+    "thumb": "/gallery/1/532017232_17851502520521494_2246823012332408389_n.jpg",
+    "folder": "1",
+    "filename": "532017232_17851502520521494_2246823012332408389_n.jpg",
+    "mtime": 1756588312238.6614
+  },
+  {
+    "id": "4",
+    "type": "image",
+    "src": "/gallery/2/534505318_17852155563521494_163022806484019126_n.jpg",
+    "thumb": "/gallery/2/534505318_17852155563521494_163022806484019126_n.jpg",
+    "folder": "2",
+    "filename": "534505318_17852155563521494_163022806484019126_n.jpg",
+    "mtime": 1756588312238.6614
+  },
+  {
+    "id": "0",
+    "type": "image",
+    "src": "/gallery/1/529760589_17851502541521494_2425886139769193656_n.jpg",
+    "thumb": "/gallery/1/529760589_17851502541521494_2425886139769193656_n.jpg",
+    "folder": "1",
+    "filename": "529760589_17851502541521494_2425886139769193656_n.jpg",
+    "mtime": 1756588312234.6614
+  },
+  {
+    "id": "1",
+    "type": "image",
+    "src": "/gallery/1/530376406_17851502532521494_1657948496357152096_n.jpg",
+    "thumb": "/gallery/1/530376406_17851502532521494_1657948496357152096_n.jpg",
+    "folder": "1",
+    "filename": "530376406_17851502532521494_1657948496357152096_n.jpg",
+    "mtime": 1756588312234.6614
+  },
+  {
+    "id": "2",
+    "type": "image",
+    "src": "/gallery/1/531899578_17851502511521494_4672844629303635307_n.jpg",
+    "thumb": "/gallery/1/531899578_17851502511521494_4672844629303635307_n.jpg",
+    "folder": "1",
+    "filename": "531899578_17851502511521494_4672844629303635307_n.jpg",
+    "mtime": 1756588312234.6614
+  }
+]

--- a/scripts/build-gallery-manifest.mjs
+++ b/scripts/build-gallery-manifest.mjs
@@ -1,0 +1,57 @@
+import { readdir, stat, readFile, writeFile } from 'node:fs/promises';
+import { extname, join, relative } from 'node:path';
+
+const ROOT = 'public/gallery';
+const extsImg = new Set(['.jpg','.jpeg','.png','.gif','.webp']);
+const extsVid = new Set(['.mp4','.webm','.mov']);
+const items = [];
+let id = 0;
+
+let imageSize;
+try {
+  ({ imageSize } = await import('image-size'));
+} catch {
+  // optional dependency not installed
+}
+
+async function walk(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const e of entries) {
+    const p = join(dir, e.name);
+    if (e.isDirectory()) await walk(p);
+    else {
+      const ext = extname(e.name).toLowerCase();
+      if (extsImg.has(ext) || extsVid.has(ext)) {
+        const s = await stat(p);
+        const type = extsVid.has(ext) ? 'video' : 'image';
+        let width, height;
+        if (type === 'image' && imageSize) {
+          try {
+            const buf = await readFile(p);
+            const dim = imageSize(buf);
+            width = dim.width;
+            height = dim.height;
+          } catch {
+            // ignore errors
+          }
+        }
+        items.push({
+          id: String(id++),
+          type,
+          src: '/' + relative('public', p).replace(/\\/g, '/'),
+          thumb: '/' + relative('public', p).replace(/\\/g, '/'),
+          folder: relative(ROOT, dir).replace(/\\/g, '/') || '/',
+          filename: e.name,
+          width,
+          height,
+          mtime: s.mtimeMs
+        });
+      }
+    }
+  }
+}
+
+await walk(ROOT);
+items.sort((a,b)=> b.mtime - a.mtime);
+await writeFile(join(ROOT, 'manifest.json'), JSON.stringify(items, null, 2));
+console.log(`Generated manifest with ${items.length} items`);

--- a/src/pages/Gallery.tsx
+++ b/src/pages/Gallery.tsx
@@ -1,151 +1,33 @@
+import { useEffect } from 'react';
 import Navigation from '@/components/Navigation';
 import Footer from '@/components/Footer';
-import { useEffect, useState } from 'react';
-import { X } from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { useTranslation } from 'react-i18next';
+import '@/styles/gallery.css';
 
 const Gallery = () => {
-  const { t } = useTranslation();
-  const [selectedImage, setSelectedImage] = useState<string | null>(null);
-  const [images, setImages] = useState<Array<{ id: string; media_url: string; permalink: string; caption?: string }>>([]);
-
   useEffect(() => {
-    const token = import.meta.env.VITE_INSTAGRAM_ACCESS_TOKEN;
-    const userId = import.meta.env.VITE_INSTAGRAM_USER_ID;
-    if (!token || !userId) return;
-
-    fetch(
-      `https://graph.instagram.com/${userId}/media?fields=id,media_url,permalink,caption&access_token=${token}`
-    )
-      .then((res) => res.json())
-      .then((data) => {
-        if (data.data) {
-          setImages(data.data);
-        }
-      })
-      .catch((err) => console.error('Instagram fetch error', err));
+    import('../scripts/gallery');
   }, []);
 
-  const openLightbox = (src: string) => {
-    setSelectedImage(src);
-    document.body.style.overflow = 'hidden';
-  };
-
-  const closeLightbox = () => {
-    setSelectedImage(null);
-    document.body.style.overflow = 'unset';
-  };
-
   return (
-    <div className="min-h-screen">
+    <div className="min-h-screen flex flex-col">
       <Navigation />
-      
-      {/* Hero Section */}
-      <section className="section-gradient py-16 md:py-24">
-        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-          <h1 className="font-lavish text-5xl md:text-6xl text-foreground mb-6">
-            {t('galleryPage.heroTitle')} <span className="text-primary">{t('galleryPage.heroHighlight')}</span>
-          </h1>
-          <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
-            {t('galleryPage.heroSubtitle')}
-          </p>
-        </div>
-      </section>
-
-      {/* Gallery Grid */}
-      <section className="section-light pb-16">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {images.map((item) => (
-              <div
-                key={item.id}
-                className="service-card cursor-pointer overflow-hidden"
-                onClick={() => openLightbox(item.media_url)}
-              >
-                <div className="relative">
-                  <img
-                    src={item.media_url}
-                    alt={item.caption || t('galleryPage.lightboxAlt')}
-                    className="w-full h-64 object-cover transition-transform duration-300 group-hover:scale-110"
-                  />
-                </div>
-              </div>
-            ))}
+      <section className="gallery-wrap flex-1 px-4 py-8">
+        <header className="gallery-header flex items-center justify-between mb-6">
+          <h1 className="text-3xl font-bold">Gallery</h1>
+          <div className="controls">
+            <label className="text-sm">
+              Sort
+              <select id="sortSelect" aria-label="Sort media" className="ml-2 border rounded p-1 text-sm">
+                <option value="newest">Newest</option>
+                <option value="oldest">Oldest</option>
+                <option value="folder">Folder</option>
+              </select>
+            </label>
           </div>
-
-          {images.length === 0 && (
-            <div className="text-center py-12">
-              <p className="text-muted-foreground">{t('galleryPage.noImages')}</p>
-            </div>
-          )}
-        </div>
+        </header>
+        <div id="galleryGrid" className="gallery-grid" aria-live="polite"></div>
+        <div id="lightbox" className="lightbox" aria-modal="true" aria-hidden="true" role="dialog"></div>
       </section>
-
-      {/* Lightbox */}
-      {selectedImage && (
-        <div 
-          className="fixed inset-0 bg-black/90 z-50 flex items-center justify-center p-4"
-          onClick={closeLightbox}
-        >
-          <div className="relative max-w-4xl max-h-full">
-            <img 
-              src={selectedImage} 
-              alt={t('galleryPage.lightboxAlt')}
-              className="max-w-full max-h-full object-contain"
-              onClick={(e) => e.stopPropagation()}
-            />
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={closeLightbox}
-              className="absolute top-4 right-4 bg-white/10 backdrop-blur-sm border-white/20 text-white hover:bg-white/20"
-            >
-              <X className="w-4 h-4" />
-            </Button>
-          </div>
-        </div>
-      )}
-
-      {/* Testimonial Section */}
-      <section className="section-dark py-16">
-        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-          <h2 className="heading-spa text-spa-dark-foreground mb-8">
-            {t('galleryPage.testimonial.title')} <span className="text-luxury-gold">{t('galleryPage.testimonial.highlight')}</span>
-          </h2>
-          
-          <div className="card-dark max-w-2xl mx-auto">
-            <blockquote className="text-lg text-spa-dark-foreground/90 italic mb-6">
-              “{t('galleryPage.testimonial.quote')}”
-            </blockquote>
-            <p className="font-semibold text-spa-dark-foreground">{t('galleryPage.testimonial.name')}</p>
-            <p className="text-luxury-gold text-sm">{t('galleryPage.testimonial.service')}</p>
-          </div>
-        </div>
-      </section>
-
-      {/* Before & After Notice */}
-      <section className="section-muted py-12">
-        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="card-spa text-center">
-            <h3 className="text-xl font-semibold text-foreground mb-4">
-              {t('galleryPage.cta.title')}
-            </h3>
-            <p className="text-muted-foreground mb-6">
-              {t('galleryPage.cta.text')}
-            </p>
-            <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Button asChild className="btn-spa">
-                <a href="/contact">{t('galleryPage.cta.primary')}</a>
-              </Button>
-              <Button asChild variant="outline" className="btn-outline-spa">
-                <a href="/services">{t('galleryPage.cta.secondary')}</a>
-              </Button>
-            </div>
-          </div>
-        </div>
-      </section>
-
       <Footer />
     </div>
   );

--- a/src/scripts/gallery.js
+++ b/src/scripts/gallery.js
@@ -1,0 +1,201 @@
+const grid = document.getElementById('galleryGrid');
+const lb = document.getElementById('lightbox');
+const sortSelect = document.getElementById('sortSelect');
+let items = [];
+let currentIndex = -1;
+
+async function loadManifest() {
+  try {
+    const res = await fetch('/gallery/manifest.json');
+    items = await res.json();
+    renderGrid(items);
+    openFromHash();
+  } catch (err) {
+    console.error('Failed to load manifest', err);
+  }
+}
+
+function renderGrid(list) {
+  grid.innerHTML = '';
+  const frag = document.createDocumentFragment();
+  list.forEach((it, i) => {
+    const a = document.createElement('a');
+    a.href = `#media=${it.id}`;
+    a.className = 'gallery-item';
+    a.dataset.index = i;
+    let media;
+    if (it.type === 'image') {
+      media = document.createElement('img');
+      media.dataset.src = it.thumb;
+      media.alt = altFrom(it);
+      media.loading = 'lazy';
+      media.className = 'gallery-thumb';
+    } else {
+      media = document.createElement('video');
+      media.dataset.src = it.thumb;
+      media.muted = true;
+      media.playsInline = true;
+      media.preload = 'none';
+      media.className = 'gallery-thumb';
+    }
+    a.appendChild(media);
+    const ov = document.createElement('span');
+    ov.className = 'overlay';
+    a.appendChild(ov);
+    a.addEventListener('click', (e) => {
+      e.preventDefault();
+      openLightboxByIndex(i);
+    });
+    frag.appendChild(a);
+  });
+  grid.appendChild(frag);
+  setupLazyLoading();
+}
+
+function setupLazyLoading() {
+  const io = new IntersectionObserver((entries) => {
+    entries.forEach((entry) => {
+      if (entry.isIntersecting) {
+        const el = entry.target;
+        el.src = el.dataset.src;
+        io.unobserve(el);
+      }
+    });
+  }, { rootMargin: '200px' });
+  grid.querySelectorAll('img[data-src],video[data-src]').forEach((el) => io.observe(el));
+}
+
+function altFrom(it) {
+  const base = it.filename.replace(/[-_]/g, ' ').replace(/\.[^.]+$/, '');
+  return `${base} — ${it.folder === '/' ? 'Gallery' : it.folder}`;
+}
+
+function openLightboxByIndex(i) {
+  currentIndex = i;
+  renderLightbox();
+  history.replaceState(null, '', `#media=${items[i].id}`);
+}
+
+function renderLightbox() {
+  const it = items[currentIndex];
+  lb.innerHTML = '';
+  const wrap = document.createElement('div');
+  wrap.className = 'lightbox-content';
+  const close = button('×', 'lightbox-close', 'Close (Esc)', closeLightbox);
+  const prev = button('‹', 'lightbox-prev', 'Previous (←)', () => nav(-1));
+  const next = button('›', 'lightbox-next', 'Next (→)', () => nav(1));
+  let media;
+  if (it.type === 'image') {
+    media = document.createElement('img');
+    media.src = it.src;
+    media.alt = altFrom(it);
+    media.className = 'lightbox-media';
+  } else {
+    media = document.createElement('video');
+    media.src = it.src;
+    media.controls = true;
+    media.className = 'lightbox-media';
+    media.autoplay = true;
+    media.playsInline = true;
+  }
+  const cap = document.createElement('div');
+  cap.className = 'caption';
+  cap.textContent = altFrom(it);
+  wrap.append(media, cap, close, prev, next);
+  lb.appendChild(wrap);
+  lb.setAttribute('aria-hidden', 'false');
+  attachKeyAndTouch();
+  trapFocus(lb);
+  prefetchNeighbors();
+}
+
+function button(txt, cls, aria, onClick) {
+  const b = document.createElement('button');
+  b.className = cls;
+  b.ariaLabel = aria;
+  b.textContent = txt;
+  b.addEventListener('click', onClick);
+  return b;
+}
+
+function nav(d) {
+  currentIndex = (currentIndex + d + items.length) % items.length;
+  renderLightbox();
+}
+
+function closeLightbox() {
+  lb.setAttribute('aria-hidden', 'true');
+  lb.innerHTML = '';
+  history.replaceState(null, '', location.pathname);
+}
+
+function attachKeyAndTouch() {
+  const onKey = (e) => {
+    if (e.key === 'Escape') closeLightbox();
+    if (e.key === 'ArrowRight') nav(1);
+    if (e.key === 'ArrowLeft') nav(-1);
+  };
+  document.addEventListener('keydown', onKey, { once: true });
+  let x0 = null;
+  lb.ontouchstart = (e) => {
+    x0 = e.touches[0].clientX;
+  };
+  lb.ontouchend = (e) => {
+    if (x0 == null) return;
+    const dx = e.changedTouches[0].clientX - x0;
+    if (dx > 40) nav(-1);
+    if (dx < -40) nav(1);
+    x0 = null;
+  };
+}
+
+function trapFocus(container) {
+  const focusable = container.querySelectorAll('button, [href], video, [tabindex]:not([tabindex="-1"])');
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  container.addEventListener('keydown', (e) => {
+    if (e.key !== 'Tab') return;
+    if (e.shiftKey) {
+      if (document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      }
+    } else {
+      if (document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  });
+  first?.focus();
+}
+
+function prefetchNeighbors() {
+  for (const d of [-1, 1]) {
+    const j = (currentIndex + d + items.length) % items.length;
+    const it = items[j];
+    if (it.type === 'image') {
+      const pre = new Image();
+      pre.src = it.src;
+    }
+  }
+}
+
+function openFromHash() {
+  const m = location.hash.match(/media=(\d+)/);
+  if (m) {
+    const idx = items.findIndex((x) => x.id === m[1]);
+    if (idx > -1) openLightboxByIndex(idx);
+  }
+}
+
+sortSelect?.addEventListener('change', () => {
+  if (sortSelect.value === 'newest') items.sort((a, b) => b.mtime - a.mtime);
+  else if (sortSelect.value === 'oldest') items.sort((a, b) => a.mtime - b.mtime);
+  else items.sort((a, b) => a.folder.localeCompare(b.folder) || a.filename.localeCompare(b.filename));
+  renderGrid(items);
+});
+
+window.addEventListener('hashchange', openFromHash);
+
+loadManifest();

--- a/src/styles/gallery.css
+++ b/src/styles/gallery.css
@@ -1,0 +1,16 @@
+/* Grid */
+.gallery-grid { column-width: 280px; column-gap: 16px; }
+@media (max-width: 640px){ .gallery-grid { column-width: 160px; column-gap: 8px; } }
+.gallery-item { break-inside: avoid; margin: 0 0 16px; position: relative; display: block; }
+.gallery-thumb { width: 100%; height: auto; display: block; border-radius: 12px; }
+.gallery-item:hover .overlay { opacity: 1; }
+.overlay { position:absolute; inset:0; background:rgba(0,0,0,.08); border-radius:12px; opacity:0; transition:.2s; }
+/* Lightbox */
+.lightbox[aria-hidden='false'] { position:fixed; inset:0; display:grid; place-items:center; background:rgba(0,0,0,.9); z-index:1000; }
+.lightbox-content { position:relative; max-width:90vw; max-height:90vh; }
+.lightbox-media { max-width:90vw; max-height:80vh; border-radius:12px; }
+.lightbox-close, .lightbox-prev, .lightbox-next { position:absolute; top:50%; transform:translateY(-50%); background:rgba(255,255,255,.15); border:none; padding:12px; border-radius:999px; cursor:pointer; color:#fff; }
+.lightbox-close { top:24px; right:24px; transform:none; }
+.lightbox-prev { left:-56px; }
+.lightbox-next { right:-56px; }
+.caption { color:#fff; margin-top:8px; text-align:center; opacity:.9; font-size:14px; }


### PR DESCRIPTION
## Summary
- generate gallery manifest from public assets at build time
- overhaul gallery page into responsive masonry grid with lightbox viewer
- add client-side script for lazy loading, navigation, and deep linking

## Testing
- `npm run prebuild`
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68b36912856c8326962a2a149ab47ade